### PR TITLE
Add CLI-based task manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.pytest_cache/
+.pytest_cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# AI_TASK_MANAGE
-chatgpt used
+# 簡単に使えるタスク管理アプリケーション
+
+このリポジトリは、コマンドラインで手軽に利用できるタスク管理ツールです。Python の標準ライブラリのみで構成されており、インストール作業を最小限に抑えています。
+
+## 主な特徴
+
+- **シンプルな操作**: `python -m task_manager` コマンドでタスクの追加・一覧・更新・完了・削除を行えます。
+- **ファイル保存**: タスクは JSON 形式で保存されるため、バックアップや他ツールとの連携が容易です。
+- **柔軟な表示**: 未完了タスクのみの表示や詳細情報の確認に対応しています。
+- **日本語メッセージ**: すべての CLI メッセージを日本語化し、直感的に利用できます。
+
+## セットアップ
+
+Python 3.11 以上がインストールされていれば追加ライブラリは不要です。ソースコードを取得後、そのまま利用できます。
+
+```
+python -m venv .venv
+source .venv/bin/activate  # Windows の場合は .venv\Scripts\activate
+pip install --upgrade pip
+pip install pytest  # テストを実行したい場合
+```
+
+## 使い方
+
+### タスクの追加
+
+```
+python -m task_manager add "レポート作成" --description "図表を更新" --due-date 2024-12-01 --priority high
+```
+
+### タスクの一覧表示
+
+```
+python -m task_manager list            # すべてのタスク
+python -m task_manager list --status pending   # 未完了のみ
+python -m task_manager list --detailed         # 詳細情報表示
+```
+
+### タスクの更新・完了・削除
+
+```
+python -m task_manager update 1 --title "企画書作成" --due-date 2024-11-20
+python -m task_manager complete 1      # 完了にする
+python -m task_manager complete 1 --undo  # 完了を取り消す
+python -m task_manager delete 1        # 削除
+```
+
+## 保存先の変更
+
+既定では `~/.simple_task_manager/tasks.json` に保存されます。環境変数 `TASK_MANAGER_DB` もしくは `--database` オプションで保存先を変更できます。
+
+```
+export TASK_MANAGER_DB=/path/to/tasks.json
+python -m task_manager list
+```
+
+## テスト
+
+pytest を利用してロジックのテストを行えます。
+
+```
+pytest
+```
+
+## ライセンス
+
+このプロジェクトは MIT ライセンスで公開されています。

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/task_manager/__init__.py
+++ b/task_manager/__init__.py
@@ -1,0 +1,7 @@
+"""Simple task management package."""
+
+from .manager import TaskManager
+from .storage import TaskStorage
+from .models import Task
+
+__all__ = ["TaskManager", "TaskStorage", "Task"]

--- a/task_manager/__main__.py
+++ b/task_manager/__main__.py
@@ -1,0 +1,7 @@
+"""Entry point for ``python -m task_manager``."""
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/task_manager/cli.py
+++ b/task_manager/cli.py
@@ -1,0 +1,212 @@
+"""Command line interface for the task manager."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .manager import TaskManager
+from .storage import TaskStorage
+from .models import Task
+
+DEFAULT_DB_PATH = Path.home() / ".simple_task_manager" / "tasks.json"
+
+
+def create_storage(path: Optional[str] = None) -> TaskStorage:
+    """Create storage instance using the configured path or default."""
+    if path is None:
+        path = os.environ.get("TASK_MANAGER_DB", str(DEFAULT_DB_PATH))
+    return TaskStorage(Path(path))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="シンプルなタスク管理ツール")
+    parser.add_argument(
+        "--database",
+        "-d",
+        dest="database",
+        help="タスクを保存する JSON ファイルのパス (既定: ~/.simple_task_manager/tasks.json)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="タスクを追加")
+    add_parser.add_argument("title", help="タスクのタイトル")
+    add_parser.add_argument("--description", "-m", default="", help="詳細メモ")
+    add_parser.add_argument("--due-date", "-t", dest="due_date", help="期限 (YYYY-MM-DD)")
+    add_parser.add_argument(
+        "--priority",
+        "-p",
+        choices=TaskManager.PRIORITY_LEVELS,
+        default="normal",
+        help="優先度 (low / normal / high)",
+    )
+
+    list_parser = subparsers.add_parser("list", help="タスクを一覧表示")
+    list_parser.add_argument(
+        "--status",
+        choices=["all", "pending", "completed"],
+        default="all",
+        help="表示対象 (all: すべて, pending: 未完了, completed: 完了済み)",
+    )
+    list_parser.add_argument(
+        "--detailed",
+        action="store_true",
+        help="詳細情報 (メモや作成日時) を表示",
+    )
+
+    complete_parser = subparsers.add_parser("complete", help="タスクを完了にする")
+    complete_parser.add_argument("task_id", type=int, help="対象のタスク ID")
+    complete_parser.add_argument(
+        "--undo",
+        action="store_true",
+        help="完了状態を解除する",
+    )
+
+    update_parser = subparsers.add_parser("update", help="タスク情報を更新")
+    update_parser.add_argument("task_id", type=int, help="対象のタスク ID")
+    update_parser.add_argument("--title")
+    update_parser.add_argument("--description")
+    update_parser.add_argument("--due-date", dest="due_date")
+    update_parser.add_argument("--priority", choices=TaskManager.PRIORITY_LEVELS)
+    update_parser.add_argument(
+        "--status",
+        choices=["pending", "completed"],
+        help="タスクの状態",
+    )
+
+    delete_parser = subparsers.add_parser("delete", help="タスクを削除")
+    delete_parser.add_argument("task_id", type=int, help="対象のタスク ID")
+
+    return parser
+
+
+def format_tasks(tasks: Iterable[Task]) -> str:
+    """Render tasks as a simple table."""
+    rows: List[List[str]] = []
+    for task in tasks:
+        rows.append(
+            [
+                str(task.id),
+                "✔" if task.completed else " ",
+                task.title,
+                task.due_date or "-",
+                task.priority,
+            ]
+        )
+    headers = ["ID", "完", "タイトル", "期限", "優先度"]
+    table = _render_table(headers, rows)
+    return table
+
+
+def format_detailed(task: Task) -> str:
+    lines = [
+        f"[{task.id}] {task.title}",
+        f"  状態: {'完了' if task.completed else '進行中'}",
+        f"  優先度: {task.priority}",
+        f"  期限: {task.due_date or '未設定'}",
+    ]
+    if task.description:
+        lines.append(f"  メモ: {task.description}")
+    lines.append(f"  作成日時: {task.created_at}")
+    lines.append(f"  更新日時: {task.updated_at}")
+    return "\n".join(lines)
+
+
+def _render_table(headers: List[str], rows: List[List[str]]) -> str:
+    if not rows:
+        return "登録済みのタスクはありません。"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for index, cell in enumerate(row):
+            widths[index] = max(widths[index], len(cell))
+    header_line = " | ".join(header.ljust(widths[i]) for i, header in enumerate(headers))
+    separator = "-+-".join("-" * width for width in widths)
+    row_lines = [
+        " | ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)) for row in rows
+    ]
+    return "\n".join([header_line, separator, *row_lines])
+
+
+def command_add(manager: TaskManager, args: argparse.Namespace) -> None:
+    task = manager.add_task(
+        title=args.title,
+        description=args.description,
+        due_date=args.due_date,
+        priority=args.priority,
+    )
+    print(f"タスクを追加しました (ID: {task.id})")
+
+
+def command_list(manager: TaskManager, args: argparse.Namespace) -> None:
+    status = None if args.status == "all" else args.status
+    tasks = manager.list_tasks(status=status)
+    if args.detailed:
+        if not tasks:
+            print("登録済みのタスクはありません。")
+            return
+        print("\n\n".join(format_detailed(task) for task in tasks))
+    else:
+        print(format_tasks(tasks))
+
+
+def command_complete(manager: TaskManager, args: argparse.Namespace) -> None:
+    completed = not args.undo
+    task = manager.complete_task(args.task_id, completed=completed)
+    state = "完了" if completed else "未完了"
+    print(f"タスク {task.id} を{state}に設定しました。")
+
+
+def command_update(manager: TaskManager, args: argparse.Namespace) -> None:
+    completed: Optional[bool]
+    if args.status is None:
+        completed = None
+    else:
+        completed = args.status == "completed"
+    task = manager.update_task(
+        args.task_id,
+        title=args.title,
+        description=args.description,
+        due_date=args.due_date,
+        priority=args.priority,
+        completed=completed,
+    )
+    print(f"タスク {task.id} を更新しました。")
+
+
+def command_delete(manager: TaskManager, args: argparse.Namespace) -> None:
+    manager.delete_task(args.task_id)
+    print(f"タスク {args.task_id} を削除しました。")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    storage = create_storage(args.database)
+    manager = TaskManager(storage)
+
+    commands = {
+        "add": command_add,
+        "list": command_list,
+        "complete": command_complete,
+        "update": command_update,
+        "delete": command_delete,
+    }
+
+    command = commands.get(args.command)
+    if command is None:
+        parser.error("不明なコマンドです。")
+        return 2
+
+    try:
+        command(manager, args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/task_manager/manager.py
+++ b/task_manager/manager.py
@@ -1,0 +1,119 @@
+"""Business logic for the task manager."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+from .models import Task
+from .storage import TaskStorage
+
+
+class TaskManager:
+    """High level API used by the CLI to manage tasks."""
+
+    PRIORITY_LEVELS = ("low", "normal", "high")
+
+    def __init__(self, storage: TaskStorage) -> None:
+        self.storage = storage
+
+    def _validate_priority(self, priority: str) -> str:
+        if priority not in self.PRIORITY_LEVELS:
+            raise ValueError(
+                f"優先度は {', '.join(self.PRIORITY_LEVELS)} のいずれかを指定してください。"
+            )
+        return priority
+
+    def _normalise_due_date(self, due_date: Optional[str]) -> Optional[str]:
+        if due_date in (None, ""):
+            return None
+        try:
+            parsed = datetime.strptime(due_date, "%Y-%m-%d")
+        except ValueError as exc:
+            raise ValueError("期限は YYYY-MM-DD 形式で指定してください。") from exc
+        return parsed.date().isoformat()
+
+    def _load(self) -> List[Task]:
+        return self.storage.load_tasks()
+
+    def _save(self, tasks: Iterable[Task]) -> None:
+        self.storage.save_tasks(tasks)
+
+    def add_task(
+        self,
+        *,
+        title: str,
+        description: str = "",
+        due_date: Optional[str] = None,
+        priority: str = "normal",
+    ) -> Task:
+        tasks = self._load()
+        due = self._normalise_due_date(due_date)
+        priority_value = self._validate_priority(priority)
+        next_id = max((task.id for task in tasks), default=0) + 1
+        new_task = Task(
+            id=next_id,
+            title=title,
+            description=description,
+            due_date=due,
+            priority=priority_value,
+        )
+        tasks.append(new_task)
+        self._save(tasks)
+        return new_task
+
+    def list_tasks(self, *, status: Optional[str] = None) -> List[Task]:
+        tasks = self._load()
+        if status == "pending":
+            tasks = [task for task in tasks if not task.completed]
+        elif status == "completed":
+            tasks = [task for task in tasks if task.completed]
+        return sorted(
+            tasks,
+            key=lambda task: (
+                task.completed,
+                task.due_date or "9999-12-31",
+                task.id,
+            ),
+        )
+
+    def _find_task(self, task_id: int, tasks: List[Task]) -> Task:
+        for task in tasks:
+            if task.id == task_id:
+                return task
+        raise ValueError(f"ID {task_id} のタスクが見つかりません。")
+
+    def update_task(
+        self,
+        task_id: int,
+        *,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        due_date: Optional[Optional[str]] = None,
+        priority: Optional[str] = None,
+        completed: Optional[bool] = None,
+    ) -> Task:
+        tasks = self._load()
+        task = self._find_task(task_id, tasks)
+        if priority is not None:
+            priority = self._validate_priority(priority)
+        if due_date is not None:
+            due_date = self._normalise_due_date(due_date)
+        task.apply_updates(
+            title=title,
+            description=description,
+            due_date=due_date,
+            priority=priority,
+            completed=completed,
+        )
+        self._save(tasks)
+        return task
+
+    def complete_task(self, task_id: int, *, completed: bool = True) -> Task:
+        return self.update_task(task_id, completed=completed)
+
+    def delete_task(self, task_id: int) -> None:
+        tasks = self._load()
+        task = self._find_task(task_id, tasks)
+        tasks.remove(task)
+        self._save(tasks)

--- a/task_manager/models.py
+++ b/task_manager/models.py
@@ -1,0 +1,74 @@
+"""Data models for the task manager application."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+
+def current_timestamp() -> str:
+    """Return the current UTC timestamp formatted for storage."""
+    return datetime.now(timezone.utc).strftime(TIMESTAMP_FORMAT)
+
+
+@dataclass
+class Task:
+    """Representation of a single task item."""
+
+    id: int
+    title: str
+    description: str = ""
+    due_date: Optional[str] = None
+    priority: str = "normal"
+    completed: bool = False
+    created_at: str = field(default_factory=current_timestamp)
+    updated_at: str = field(default_factory=current_timestamp)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON serialisable representation of the task."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Task":
+        """Create a task instance from stored JSON data."""
+        defaults = {
+            "description": "",
+            "due_date": None,
+            "priority": "normal",
+            "completed": False,
+            "created_at": current_timestamp(),
+            "updated_at": current_timestamp(),
+        }
+        merged: Dict[str, Any] = {**defaults, **data}
+        return cls(**merged)
+
+    def mark_completed(self, completed: bool = True) -> None:
+        """Toggle the completion state and update the timestamp."""
+        self.completed = completed
+        self.updated_at = current_timestamp()
+
+    def apply_updates(
+        self,
+        *,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        due_date: Optional[Optional[str]] = None,
+        priority: Optional[str] = None,
+        completed: Optional[bool] = None,
+    ) -> None:
+        """Update editable fields and refresh the ``updated_at`` timestamp."""
+
+        if title is not None:
+            self.title = title
+        if description is not None:
+            self.description = description
+        if due_date is not None:
+            self.due_date = due_date
+        if priority is not None:
+            self.priority = priority
+        if completed is not None:
+            self.completed = completed
+        self.updated_at = current_timestamp()

--- a/task_manager/storage.py
+++ b/task_manager/storage.py
@@ -1,0 +1,31 @@
+"""File based storage backend for task data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from .models import Task
+
+
+class TaskStorage:
+    """Persist tasks to a JSON file on disk."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def load_tasks(self) -> List[Task]:
+        """Load all stored tasks."""
+        if not self.path.exists():
+            return []
+        with self.path.open("r", encoding="utf-8") as handle:
+            raw_tasks = json.load(handle)
+        return [Task.from_dict(item) for item in raw_tasks]
+
+    def save_tasks(self, tasks: Iterable[Task]) -> None:
+        """Persist the given tasks list."""
+        serialisable = [task.to_dict() for task in tasks]
+        with self.path.open("w", encoding="utf-8") as handle:
+            json.dump(serialisable, handle, ensure_ascii=False, indent=2)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,89 @@
+"""Tests for the task manager domain logic."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from task_manager.manager import TaskManager
+from task_manager.storage import TaskStorage
+
+
+@pytest.fixture()
+def manager(tmp_path: Path) -> TaskManager:
+    storage_path = tmp_path / "tasks.json"
+    storage = TaskStorage(storage_path)
+    return TaskManager(storage)
+
+
+def read_raw_tasks(path: Path) -> list[dict[str, object]]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_add_and_list_tasks(manager: TaskManager, tmp_path: Path) -> None:
+    manager.add_task(title="書類作成", description="請求書のドラフト", due_date="2024-12-01")
+    manager.add_task(title="買い物", priority="high")
+    all_tasks = manager.list_tasks()
+    assert len(all_tasks) == 2
+    assert all_tasks[0].title == "書類作成"
+    assert all_tasks[0].due_date == "2024-12-01"
+    pending_tasks = manager.list_tasks(status="pending")
+    assert len(pending_tasks) == 2
+
+
+def test_complete_task(manager: TaskManager) -> None:
+    task = manager.add_task(title="散歩")
+    assert not task.completed
+    manager.complete_task(task.id)
+    stored = manager.list_tasks()
+    assert stored[0].completed
+    manager.complete_task(task.id, completed=False)
+    assert not manager.list_tasks()[0].completed
+
+
+def test_update_task(manager: TaskManager) -> None:
+    task = manager.add_task(title="洗濯", due_date="2024-01-10")
+    updated = manager.update_task(
+        task.id,
+        title="洗濯物を畳む",
+        description="Tシャツとタオル",
+        due_date="2024-01-12",
+        priority="high",
+        completed=True,
+    )
+    assert updated.title == "洗濯物を畳む"
+    assert updated.description == "Tシャツとタオル"
+    assert updated.due_date == "2024-01-12"
+    assert updated.priority == "high"
+    assert updated.completed is True
+
+
+def test_delete_task(manager: TaskManager, tmp_path: Path) -> None:
+    task1 = manager.add_task(title="メール送信")
+    task2 = manager.add_task(title="資料レビュー")
+    manager.delete_task(task1.id)
+    remaining = manager.list_tasks()
+    assert len(remaining) == 1
+    assert remaining[0].id == task2.id
+
+
+def test_invalid_priority(manager: TaskManager) -> None:
+    with pytest.raises(ValueError):
+        manager.add_task(title="無効な優先度", priority="urgent")
+
+
+def test_invalid_due_date(manager: TaskManager) -> None:
+    with pytest.raises(ValueError):
+        manager.add_task(title="日付", due_date="2024/12/01")
+
+
+def test_storage_persists_data(tmp_path: Path) -> None:
+    storage_path = tmp_path / "tasks.json"
+    manager = TaskManager(TaskStorage(storage_path))
+    manager.add_task(title="掃除", description="玄関")
+    raw = read_raw_tasks(storage_path)
+    assert raw[0]["title"] == "掃除"
+    assert raw[0]["description"] == "玄関"


### PR DESCRIPTION
## Summary
- implement a command-line task manager with JSON storage, filtering, and update commands
- cover manager behaviour with pytest-based unit tests and ensure the package is importable via pytest.ini
- document usage in Japanese, add an MIT license, and ignore compiled artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0bae611b4832f9a450e204331d82b