### PR TITLE
Add simple CLI task manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.swp
+.pytest_cache/
+.venv/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
-# AI_TASK_MANAGE
-chatgpt used
+# Simple Task Manager
+
+A lightweight command-line application for organising tasks. Tasks can include optional descriptions and due dates and are stored in a JSON file so they persist between runs.
+
+## Features
+
+- Add new tasks with optional description and due date
+- List all tasks or filter by completion status
+- Update titles, descriptions, completion status, and due dates
+- Remove tasks that are no longer needed
+- Persist tasks to a JSON file for later sessions
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10 or newer
+
+### Installation
+
+No third-party dependencies are required. You may create a virtual environment if desired, but the standard library is sufficient.
+
+### Usage
+
+Every command accepts an optional `--storage` argument that sets the path of the JSON file used for persistence. When omitted, `tasks.json` in the current directory is used.
+
+Create a task:
+
+```bash
+python -m app.main add "Write report" --description "Summarise Q2 results" --due 2025-06-30
+```
+
+List tasks:
+
+```bash
+python -m app.main list --status pending
+```
+
+Mark a task as complete and remove the due date:
+
+```bash
+python -m app.main update 1 --completed true --clear-due
+```
+
+Delete a task:
+
+```bash
+python -m app.main delete 1
+```
+
+### Running Tests
+
+```bash
+pytest
+```
+
+## Project Structure
+
+```
+app/
+├── __init__.py
+├── main.py          # Command-line interface
+├── models.py        # Dataclass representing a task
+└── repository.py    # Task repository with optional JSON persistence
+
+requirements.txt     # Documented dependencies (none required)
+tests/
+└── test_app.py      # Unit tests for the repository and CLI
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from typing import Iterable, Optional, Sequence
+
+from .models import Task
+from .repository import TaskRepository
+
+
+def _parse_due_date(value: Optional[str]) -> Optional[date]:
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("Due date must use the YYYY-MM-DD format") from exc
+
+
+def _format_task(task: Task) -> str:
+    status = "✓" if task.completed else "✗"
+    due = task.due_date.isoformat() if task.due_date else "-"
+    description = f" — {task.description}" if task.description else ""
+    return f"[{status}] #{task.id} {task.title} (due: {due}){description}"
+
+
+def _print_tasks(tasks: Iterable[Task]) -> None:
+    tasks = list(tasks)
+    if not tasks:
+        print("No tasks found.")
+        return
+
+    for task in tasks:
+        print(_format_task(task))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage tasks from the command line.")
+    parser.add_argument(
+        "--storage",
+        default="tasks.json",
+        help="Path to the JSON file where tasks are stored (default: %(default)s)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Create a new task")
+    add_parser.add_argument("title", help="Title of the task")
+    add_parser.add_argument("--description", default="", help="Optional task description")
+    add_parser.add_argument("--due", help="Optional due date in YYYY-MM-DD format")
+
+    list_parser = subparsers.add_parser("list", help="List stored tasks")
+    list_parser.add_argument(
+        "--status",
+        choices=["all", "pending", "completed"],
+        default="all",
+        help="Filter tasks by completion state",
+    )
+
+    update_parser = subparsers.add_parser("update", help="Update an existing task")
+    update_parser.add_argument("task_id", type=int, help="Identifier of the task to update")
+    update_parser.add_argument("--title", help="New title for the task")
+    update_parser.add_argument("--description", help="New description for the task")
+    update_parser.add_argument("--due", help="New due date in YYYY-MM-DD format")
+    update_parser.add_argument("--clear-due", action="store_true", help="Remove the due date")
+    update_parser.add_argument(
+        "--completed",
+        choices=["true", "false"],
+        help="Mark the task as completed or pending",
+    )
+
+    delete_parser = subparsers.add_parser("delete", help="Delete a task")
+    delete_parser.add_argument("task_id", type=int, help="Identifier of the task to delete")
+
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repository = TaskRepository(storage_path=args.storage)
+
+    try:
+        if args.command == "add":
+            due_date = _parse_due_date(args.due)
+            task = repository.create_task(
+                title=args.title,
+                description=args.description,
+                due_date=due_date,
+            )
+            print(f"Created task #{task.id}: {task.title}")
+            return 0
+
+        if args.command == "list":
+            status_map = {"all": None, "pending": False, "completed": True}
+            tasks = repository.list_tasks(completed=status_map[args.status])
+            _print_tasks(tasks)
+            return 0
+
+        if args.command == "update":
+            kwargs = {}
+            if args.title is not None:
+                kwargs["title"] = args.title
+            if args.description is not None:
+                kwargs["description"] = args.description
+
+            if args.clear_due:
+                kwargs["due_date"] = None
+            elif args.due is not None:
+                kwargs["due_date"] = _parse_due_date(args.due)
+
+            if args.completed is not None:
+                kwargs["completed"] = args.completed == "true"
+
+            repository.update_task(args.task_id, **kwargs)
+            print(f"Updated task #{args.task_id}")
+            return 0
+
+        if args.command == "delete":
+            removed = repository.delete_task(args.task_id)
+            if not removed:
+                print(f"Task #{args.task_id} was not found.")
+                return 1
+            print(f"Deleted task #{args.task_id}")
+            return 0
+    except ValueError as exc:
+        parser.error(str(exc))
+    except KeyError:
+        print(f"Task #{getattr(args, 'task_id', 'unknown')} was not found.")
+        return 1
+
+    parser.error("Unknown command")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class Task:
+    """Simple representation of a task managed by the application."""
+
+    id: int
+    title: str
+    description: str = ""
+    completed: bool = False
+    due_date: Optional[date] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the task to a JSON-friendly dictionary."""
+
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "completed": self.completed,
+            "due_date": self.due_date.isoformat() if self.due_date else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Task":
+        """Deserialize a task from a dictionary produced by :meth:`to_dict`."""
+
+        due_date_value = data.get("due_date")
+        parsed_due_date = date.fromisoformat(due_date_value) if due_date_value else None
+        return cls(
+            id=int(data["id"]),
+            title=str(data["title"]),
+            description=str(data.get("description", "")),
+            completed=bool(data.get("completed", False)),
+            due_date=parsed_due_date,
+        )

--- a/app/repository.py
+++ b/app/repository.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from threading import Lock
+from typing import Dict, Iterable, Optional
+
+from .models import Task
+
+
+_UNSET = object()
+
+
+@dataclass
+class TaskRepository:
+    """Manage tasks in memory with optional JSON persistence."""
+
+    storage_path: Optional[Path] = None
+    _tasks: Dict[int, Task] = field(default_factory=dict, init=False)
+    _next_id: int = field(default=1, init=False)
+    _lock: Lock = field(default_factory=Lock, init=False)
+
+    def __post_init__(self) -> None:
+        if self.storage_path:
+            self.storage_path = Path(self.storage_path)
+            self._load()
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def list_tasks(self, completed: Optional[bool] = None) -> Iterable[Task]:
+        """Return all tasks, optionally filtering by completion state."""
+
+        with self._lock:
+            tasks = list(self._tasks.values())
+
+        if completed is None:
+            return tasks
+
+        return [task for task in tasks if task.completed is completed]
+
+    def create_task(
+        self,
+        title: str,
+        description: str = "",
+        due_date: Optional[date] = None,
+    ) -> Task:
+        """Create a new task and persist it if persistence is enabled."""
+
+        title = title.strip()
+        if not title:
+            raise ValueError("title must not be empty")
+
+        with self._lock:
+            task = Task(
+                id=self._next_id,
+                title=title,
+                description=description.strip(),
+                completed=False,
+                due_date=due_date,
+            )
+            self._tasks[self._next_id] = task
+            self._next_id += 1
+            self._save_locked()
+
+        return task
+
+    def get_task(self, task_id: int) -> Optional[Task]:
+        """Retrieve a single task by its identifier."""
+
+        with self._lock:
+            return self._tasks.get(task_id)
+
+    def update_task(
+        self,
+        task_id: int,
+        *,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        due_date: object = _UNSET,
+        completed: Optional[bool] = None,
+    ) -> Task:
+        """Update an existing task and persist the change."""
+
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                raise KeyError(task_id)
+
+            if title is not None:
+                title = title.strip()
+                if not title:
+                    raise ValueError("title must not be empty")
+                task.title = title
+
+            if description is not None:
+                task.description = description.strip()
+
+            if due_date is not _UNSET:
+                task.due_date = due_date  # type: ignore[assignment]
+
+            if completed is not None:
+                task.completed = completed
+
+            self._tasks[task_id] = task
+            self._save_locked()
+            return task
+
+    def delete_task(self, task_id: int) -> bool:
+        """Remove a task from storage and persist if necessary."""
+
+        with self._lock:
+            removed = self._tasks.pop(task_id, None) is not None
+            if removed:
+                self._save_locked()
+            return removed
+
+    def reset(self) -> None:
+        """Clear all stored tasks and reset the identifier counter."""
+
+        with self._lock:
+            self._tasks.clear()
+            self._next_id = 1
+            self._save_locked()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.storage_path or not self.storage_path.exists():
+            return
+
+        try:
+            with self.storage_path.open("r", encoding="utf-8") as handle:
+                raw_tasks = json.load(handle)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Failed to parse task storage file") from exc
+
+        tasks = [Task.from_dict(raw) for raw in raw_tasks]
+        self._tasks = {task.id: task for task in tasks}
+        self._next_id = (max(self._tasks.keys()) + 1) if self._tasks else 1
+
+    def _save_locked(self) -> None:
+        if not self.storage_path:
+            return
+
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        data = [task.to_dict() for task in sorted(self._tasks.values(), key=lambda t: t.id)]
+        with self.storage_path.open("w", encoding="utf-8") as handle:
+            json.dump(data, handle, ensure_ascii=False, indent=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# This project uses only the Python standard library. No external dependencies are required.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,140 @@
+from datetime import date, timedelta
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import main
+from app.repository import TaskRepository
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> TaskRepository:
+    storage = tmp_path / "tasks.json"
+    return TaskRepository(storage_path=storage)
+
+
+def test_create_and_get_task(repository: TaskRepository):
+    due = date.today() + timedelta(days=7)
+    task = repository.create_task("Write documentation", description="Update README", due_date=due)
+
+    fetched = repository.get_task(task.id)
+    assert fetched is not None
+    assert fetched.title == "Write documentation"
+    assert fetched.description == "Update README"
+    assert fetched.due_date == due
+    assert fetched.completed is False
+
+
+def test_list_and_filter_tasks(repository: TaskRepository):
+    first = repository.create_task("Task A")
+    second = repository.create_task("Task B")
+    repository.update_task(second.id, completed=True)
+
+    all_tasks = list(repository.list_tasks())
+    assert len(all_tasks) == 2
+
+    completed_tasks = list(repository.list_tasks(completed=True))
+    assert [task.id for task in completed_tasks] == [second.id]
+
+    pending_tasks = list(repository.list_tasks(completed=False))
+    assert [task.id for task in pending_tasks] == [first.id]
+
+
+def test_update_and_delete_task(repository: TaskRepository):
+    task = repository.create_task("Temporary", description="To be updated")
+
+    updated = repository.update_task(
+        task.id,
+        title="Updated title",
+        description="New description",
+        completed=True,
+    )
+    assert updated.title == "Updated title"
+    assert updated.description == "New description"
+    assert updated.completed is True
+
+    repository.update_task(task.id, due_date=date(2025, 1, 1))
+    repository.update_task(task.id, due_date=None)
+    assert repository.get_task(task.id).due_date is None
+
+    assert repository.delete_task(task.id) is True
+    assert repository.get_task(task.id) is None
+    assert repository.delete_task(task.id) is False
+
+
+def test_validation_and_error_handling(repository: TaskRepository):
+    with pytest.raises(ValueError):
+        repository.create_task("   ")
+
+    task = repository.create_task("Valid title")
+    with pytest.raises(ValueError):
+        repository.update_task(task.id, title="")
+
+    with pytest.raises(KeyError):
+        repository.update_task(9999, title="Unknown")
+
+
+def test_persistence_between_sessions(tmp_path: Path):
+    storage = tmp_path / "tasks.json"
+    repo_a = TaskRepository(storage_path=storage)
+    repo_a.create_task("Persistent task", due_date=date(2030, 1, 1))
+
+    repo_b = TaskRepository(storage_path=storage)
+    tasks = list(repo_b.list_tasks())
+    assert len(tasks) == 1
+    assert tasks[0].title == "Persistent task"
+    assert tasks[0].due_date == date(2030, 1, 1)
+
+
+def test_cli_flow(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    storage = tmp_path / "cli_tasks.json"
+
+    # Listing before creation shows no tasks.
+    exit_code = main(["--storage", str(storage), "list"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "No tasks found" in output
+
+    exit_code = main(
+        [
+            "--storage",
+            str(storage),
+            "add",
+            "Buy milk",
+            "--description",
+            "From the local store",
+            "--due",
+            "2025-05-01",
+        ]
+    )
+    assert exit_code == 0
+    capsys.readouterr()
+
+    exit_code = main(["--storage", str(storage), "list", "--status", "pending"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "Buy milk" in output
+    assert "✗" in output
+
+    # Mark as completed
+    exit_code = main(["--storage", str(storage), "update", "1", "--completed", "true"])
+    assert exit_code == 0
+    capsys.readouterr()
+
+    exit_code = main(["--storage", str(storage), "list", "--status", "completed"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "✓" in output
+
+    exit_code = main(["--storage", str(storage), "delete", "1"])
+    assert exit_code == 0
+
+    exit_code = main(["--storage", str(storage), "delete", "999"])
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert "not found" in output.lower()


### PR DESCRIPTION
## Summary
- implement a lightweight CLI for creating, listing, updating, and deleting tasks with optional due dates
- add dataclass-based task model and repository with optional JSON persistence
- document command usage and cover repository plus CLI flows with pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0bb09402c832fb3a3b175f8ff36cd